### PR TITLE
Mod the brokerid by the largest 32bit integer

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,9 @@ default[:kafka][:generic_opts] = nil
 default[:kafka][:init_style] = :sysv
 
 # General configuration
-default[:kafka][:broker_id] = node[:ipaddress].gsub('.', '')
+# Mod the broker id by the largest 32 bit unsigned int to avoid kafka
+# choking on the value when it tries to start up.
+default[:kafka][:broker_id] = node[:ipaddress].gsub('.', '').to_i % 2**31
 default[:kafka][:message_max_bytes] = 1_000_000
 default[:kafka][:num_network_threads] = 3
 default[:kafka][:num_io_threads] = 8


### PR DESCRIPTION
Kafka treats the broker id as a 32 bit integer but if your IP address without dots is greater than the largest 32 bit integer than Kafka will choke on start up.

Original commit by @clofresh [here](https://github.com/DataDog/kafka-cookbook/commit/a3dea34ae31efe617675e506ef551435ad1038f0). Copied into a new commit based off a more up-to-date upstream with the right attributes file.
