### PR TITLE
Add a zookeeper path attribute for the connection string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ well as configuring Kafka.
 * `node[:kafka][:zookeeper][:connection_timeout_ms]` - The max time that the client waits to establish a connection to ZooKeeper.
 * `node[:kafka][:zookeeper][:session_timeout_ms]` - ZooKeeper session timeout.
 * `node[:kafka][:zookeeper][:sync_time_ms]` - How far a ZK follower can be behind a ZK leader.
+* `node[:kafka][:zookeeper][:path]` - An optional zookeeper path for kafka brokers to prefix their zookeeper nodes.
 
 ### zookeeper
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,3 +83,4 @@ default[:kafka][:zookeeper][:connect] = []
 default[:kafka][:zookeeper][:connection_timeout_ms] = 6000
 default[:kafka][:zookeeper][:session_timeout_ms] = 6000
 default[:kafka][:zookeeper][:sync_time_ms] = 2000
+default[:kafka][:zookeeper][:path] = nil

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -19,6 +19,9 @@ template ::File.join(node[:kafka][:config_dir], node[:kafka][:config]) do
   owner  node[:kafka][:user]
   group  node[:kafka][:group]
   mode   '644'
+  variables({
+    zookeeper_connect: %(#{node[:kafka][:zookeeper][:connect].join(',')}#{node[:kafka][:zookeeper][:path]})
+  })
 end
 
 case node[:kafka][:init_style].to_sym

--- a/templates/default/server.properties.erb
+++ b/templates/default/server.properties.erb
@@ -169,7 +169,7 @@
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
 # root directory for all kafka znodes.
-<%= render 'partials/option.erb', variables: {key: 'zookeeper.connect', value: node[:kafka][:zookeeper][:connect].join(',')} -%>
+<%= render 'partials/option.erb', variables: {key: 'zookeeper.connect', value: @zookeeper_connect -%>
 
 # the max time that the client waits to establish a connection to zookeeper
 <%= render 'partials/option.erb', variables: {key: 'zookeeper.connection.timeout.ms', value: node[:kafka][:zookeeper][:connection_timeout_ms]} -%>


### PR DESCRIPTION
Allows you to set a prefix path for your zookeeper connection so all the Kafka metadata will live under that prefix. I'm not completely sure this is the best approach for this change, so I'll happily change up how this works if you'd prefer a different way.
