### PR TITLE
Create log.dirs string, Fixes #34, update to 0.1.1

### DIFF
--- a/libraries/kafka_helpers.rb
+++ b/libraries/kafka_helpers.rb
@@ -84,6 +84,10 @@ def zookeeper_connect_string
   end
 end
 
+def kafka_log_dirs_string
+  node[:kafka][:log][:dirs].join(',')
+end
+
 def zookeeper_init_opts
   @zookeeper_init_opts ||= kafka_create_init_opts('zookeeper')
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'mths@sdrbrg.se'
 license          'Apache 2.0'
 description      'Installs and configures a Kafka broker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 recipe 'kafka::source', 'Downloads, compiles and installs Kafka from source releases'
 recipe 'kafka::binary', 'Downloads, extracts and installs Kafka from binary releases'

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -20,7 +20,8 @@ template ::File.join(node[:kafka][:config_dir], node[:kafka][:config]) do
   group node[:kafka][:group]
   mode '644'
   variables({
-    zookeeper_connect: zookeeper_connect_string
+    zookeeper_connect: zookeeper_connect_string,
+    log_dirs: kafka_log_dirs_string
   })
   helper(:config) { node[:kafka] }
   helper(:kafka_v0_8_0?) { node[:kafka][:version] == '0.8.0' }

--- a/templates/default/server.properties.erb
+++ b/templates/default/server.properties.erb
@@ -71,7 +71,7 @@
 <%= render 'partials/option.erb', variables: {key: 'num.partitions', value: config.num_partitions} -%>
 
 # The directories in which the log data is kept
-<%= render 'partials/option.erb', variables: {key: 'log.dirs', value: config.log.dirs.join(',')} -%>
+<%= render 'partials/option.erb', variables: {key: 'log.dirs', value: @log_dirs} -%>
 
 # The maximum size of a single log file
 <%= render 'partials/option.erb', variables: {key: 'log.segment.bytes', value: config.log.segment_bytes} -%>


### PR DESCRIPTION
The .join(',') was not being evaluated in server.properties.erb, which
was causing input like ["dir1", "dir2", "dir3"] to cause output of
log.dirs=dir1=dir2=dir3
