### PR TITLE
Fix: Kafka service start doesn't start the process.

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -54,6 +54,6 @@ end
 
 service 'kafka' do
   provider kafka_init_opts[:provider]
-  supports start: true, stop: true, restart: true
+  supports start: true, stop: true, restart: true, status: true
   action [:enable]
 end

--- a/recipes/zookeeper.rb
+++ b/recipes/zookeeper.rb
@@ -57,6 +57,6 @@ end
 
 service 'zookeeper' do
   provider zookeeper_init_opts[:provider]
-  supports start: true, stop: true, restart: true
+  supports start: true, stop: true, restart: true, status: true
   action [:enable, :start]
 end


### PR DESCRIPTION
Added supports status: true so that service start will not fall back on checking the process table for kafka. The latter will show as kafka running since zookeeper process runs as kafka user.
