### PR TITLE
Switch java recommendation to suggests

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe 'kafka::source', 'Downloads, compiles and installs Kafka from source rele
 recipe 'kafka::binary', 'Downloads, extracts and installs Kafka from binary releases'
 recipe 'kafka::zookeeper', 'Setups standalone ZooKeeper instance using the ZooKeeper version that is bundled with Kafka'
 
-recommends 'java', '~> 1.22'
+suggests 'java', '~> 1.22'
 
 %w(centos fedora debian ubuntu).each do |os|
   supports os


### PR DESCRIPTION
In essence, Berkshelf will always download a recommends but not a suggests. Our org uses a separate Java cookbook, so the version pin here presents a bit of a problem, and in some cases, we trust that the AMI we build off of will have Java. So in order to appease Berkshelf but still make Java a known system requirement, bumping this down to suggests means other orgs can not be dependent on the community Java cookbook.
