### PR TITLE
Notify kafka restart on config changes

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -12,6 +12,7 @@ template ::File.join(node[:kafka][:config_dir], node[:kafka][:log4j_config]) do
     process: 'kafka',
     log_dir: node[:kafka][:log_dir]
   })
+  notifies :restart, 'service[kafka]', :delayed
 end
 
 template ::File.join(node[:kafka][:config_dir], node[:kafka][:config]) do
@@ -25,6 +26,7 @@ template ::File.join(node[:kafka][:config_dir], node[:kafka][:config]) do
   })
   helper(:config) { node[:kafka] }
   helper(:kafka_v0_8_0?) { node[:kafka][:version] == '0.8.0' }
+  notifies :restart, 'service[kafka]', :delayed
 end
 
 template kafka_init_opts[:env_path] do
@@ -38,6 +40,7 @@ template kafka_init_opts[:env_path] do
     config: node[:kafka][:config],
     log4j_config: 'log4j.properties'
   })
+  notifies :restart, 'service[kafka]', :delayed
 end
 
 template kafka_init_opts[:script_path] do
@@ -50,6 +53,7 @@ template kafka_init_opts[:script_path] do
     port: node[:kafka][:port],
     user: node[:kafka][:user]
   })
+  notifies :restart, 'service[kafka]', :delayed
 end
 
 service 'kafka' do


### PR DESCRIPTION
should resolve issue #42
alternative is to solve via wrapper cookbook:

```
[
  ::File.join(node[:kafka][:config_dir], node[:kafka][:log4j_config]),
  ::File.join(node[:kafka][:config_dir], node[:kafka][:config]),
  kafka_init_opts[:env_path],
  kafka_init_opts[:script_path]
].each do |template|

  begin
    r = resources(template: template)
    r.notifies(:restart, "service[kafka]")
  rescue Chef::Exceptions::ResourceNotFound
    log "Kafka template file not found: '#{template}' -- skipping restart notification"
  end

end
```
