### PR TITLE
Modified ZK template to work with ZK Quorum

### DIFF
--- a/templates/default/zookeeper.properties.erb
+++ b/templates/default/zookeeper.properties.erb
@@ -21,3 +21,18 @@ clientPort=<%= node[:zookeeper][:port] %>
 
 # Disable the per-ip limit on the number of connections since this is a non-production config
 maxClientCnxns=<%= node[:zookeeper][:max_client_connections] %>
+
+# Tick Time for zookeeper servers
+tickTime=2000
+
+# Timeouts ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader
+initLimit=10
+
+# How far out of date a server can be from a leader
+syncLimit=5
+
+# Servers participating in zookeeper quorum
+<% require 'ipaddr' %>
+<% node[:zookeeper][:servers].each do |server| %> 
+<%="server.#{IPAddr.new(server).mask("0.0.0.255").to_i}=#{server}:2888:3888" %>
+<% end %>


### PR DESCRIPTION
The current ZK template only supports a stand alone ZK server. The proposed change can be used to build a ZK quorum in case working with a cluster. This will also work for a standalone ZK server. 
