### PR TITLE
Do not require host.name in server.properties

### DIFF
--- a/recipes/_defaults.rb
+++ b/recipes/_defaults.rb
@@ -10,7 +10,3 @@ end
 unless broker_attribute?(:port)
   node.default.kafka.broker.port = 6667
 end
-
-unless broker_attribute?(:host, :name)
-  node.default.kafka.broker.host_name = node.hostname
-end


### PR DESCRIPTION
Kafka uses this attribute to determine which address to bind, and you need to be able to omit host.name to bind to all interfaces.

From the [Kafka 0.8 docs](https://kafka.apache.org/08/configuration.html): "Hostname of broker. If this is set, it will only bind to this address. If this is not set, it will bind to all interfaces, and publish one to ZK."
