### PR TITLE
Changes to allow users of cookbook to implement custom logic to restart

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,6 +97,13 @@ default.kafka.automatic_start = false
 default.kafka.automatic_restart = false
 
 #
+# Attribute to set the recipe to used to coordinate Kafka service start
+# if nothing is set the default recipe "coordiante" will be used
+# Refer to issue #58 for details
+#
+default.kafka.start_coordination.recipe = 'kafka::_coordinate'
+
+#
 # `broker` namespace for configuration of a broker.
 # Initially set it to an empty Hash to avoid having `fetch(:broker, {})`
 # statements in helper methods and the alike.

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -16,7 +16,7 @@ template ::File.join(node.kafka.config_dir, 'log4j.properties') do
     config: node.kafka.log4j,
   })
   if restart_on_configuration_change?
-    notifies :restart, 'service[kafka]', :delayed
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
 end
 
@@ -30,7 +30,7 @@ template ::File.join(node.kafka.config_dir, 'server.properties') do
   end
   helpers(Kafka::Configuration)
   if restart_on_configuration_change?
-    notifies :restart, 'service[kafka]', :delayed
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
 end
 
@@ -43,7 +43,7 @@ template kafka_init_opts[:env_path] do
     main_class: 'kafka.Kafka',
   })
   if restart_on_configuration_change?
-    notifies :restart, 'service[kafka]', :delayed
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
 end
 
@@ -61,12 +61,8 @@ template kafka_init_opts[:script_path] do
     !!broker_attribute?(:controlled, :shutdown, :enable)
   end
   if restart_on_configuration_change?
-    notifies :restart, 'service[kafka]', :delayed
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
 end
 
-service 'kafka' do
-  provider kafka_init_opts[:provider]
-  supports start: true, stop: true, restart: true, status: true
-  action kafka_service_actions
-end
+include_recipe node.kafka.start_coordination.recipe

--- a/recipes/_coordinate.rb
+++ b/recipes/_coordinate.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: kafka
+# Recipe:: _coordinate
+# Function:: Default recipe to start/restart Kafka service
+#            Refer issue #58 for details
+#
+ruby_block "coordinate-kafka-start" do
+  block do
+    Chef::Log.debug ("Default recipe to coordinate Kafka start is used")
+  end
+  action :nothing
+  notifies :restart, 'service[kafka]', :delayed
+end
+
+service 'kafka' do
+  provider kafka_init_opts[:provider]
+  supports start: true, stop: true, restart: true, status: true
+  action kafka_service_actions
+end
+

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -457,7 +457,7 @@ describe 'kafka::_configure' do
 
         it 'restarts kafka when configuration is changed' do
           config_templates.each do |template|
-            expect(template).to notify('service[kafka]').to(:restart)
+            expect(template).to notify('ruby_block[coordinate-kafka-start]').to(:create)
           end
         end
 


### PR DESCRIPTION
Changes in this PR will let users of the cookbook to be able to implement restart logic for Kafka service in their wrapper cookbook. Please refer request in issue #58 .

Note that the changes are made in v0.6.0 of the cookbook.
