### PR TITLE
Increases max open files

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -94,7 +94,7 @@ default.kafka.init_style = :sysv
 
 #
 # The ulimit file limit
-default.kafka.ulimit_file = nil
+default.kafka.ulimit_file = 65535
 
 #
 # Automatically start kafka service.


### PR DESCRIPTION
Resolves issue #79

Users are almost guaranteed to run into problems if the ulimit file is set to nil. Sets a default value so that it is added to the upstart config.