### PR TITLE
Changes md5 to downcase all letters

### DIFF
--- a/providers/download.rb
+++ b/providers/download.rb
@@ -20,7 +20,7 @@ action :create do
   ruby_block 'kafka-validate-download' do
     block do
       if known_md5 && !known_md5.empty?
-        unless (checksum = Digest::MD5.file(local_file_path).hexdigest) == known_md5
+        unless (checksum = Digest::MD5.file(local_file_path).hexdigest) == known_md5.downcase
           Chef::Application.fatal! %(Downloaded tarball checksum (#{checksum}) does not match known checksum (#{known_md5}))
         end
       else


### PR DESCRIPTION
Fixes issue #81 

To test this, I couldn't just export the environemnt variable `KAFKA_MD5` and then run kitchen converge. 
I actually had to edit the kitchen.yml file with the following MD5

.kitchen.yml that fails without patch, succeeded with patch. Notice how the `D` is uppercase. 

        md5_checksum: "7541ed160f1b3aa1a5334d4e782ba4D3"