### PR TITLE
Allow attribute to configure hard stop delay

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -119,6 +119,11 @@ default.kafka.automatic_restart = false
 default.kafka.start_coordination.recipe = 'kafka::_coordinate'
 
 #
+# Attribute to set the timeout in seconds when stopping the broker
+# before trying a hard stop
+default.kafka.hard_stop_delay = 10
+
+#
 # `broker` namespace for configuration of a broker.
 # Initially set to an empty Hash to avoid having `fetch(:broker, {})`
 # statements in helper methods and the alike.

--- a/templates/default/systemd/default.erb
+++ b/templates/default/systemd/default.erb
@@ -6,6 +6,7 @@ User=<%= @user %>
 EnvironmentFile=<%= @env_path %>
 ExecStart=/bin/bash $KAFKA_RUN $KAFKA_ARGS $KAFKA_CONFIG
 TimeoutSec=10
+TimeoutStopSec=<%= node.kafka.hard_stop_delay %>
 <% if node.kafka.ulimit_file %>
 LimitNOFILE=<%= node.kafka.ulimit_file %>
 <% end %>

--- a/templates/default/sysv/debian.erb
+++ b/templates/default/sysv/debian.erb
@@ -46,7 +46,7 @@ do_stop()
   RETVAL=$?
   while pidofproc "$PIDFILE" "$KAFKA"; do sleep 1; done
   <% else %>
-  start-stop-daemon --stop --quiet --oknodo --retry=TERM/10/KILL/5 --pidfile "$PIDFILE"
+  start-stop-daemon --stop --quiet --oknodo --retry=TERM/<%= node.kafka.hard_stop_delay %>/KILL/5 --pidfile "$PIDFILE"
   RETVAL="$?"
   <% end %>
   rm -f $PIDFILE

--- a/templates/default/sysv/default.erb
+++ b/templates/default/sysv/default.erb
@@ -60,7 +60,7 @@ stop() {
   echo
   rm -f "$PIDFILE"
   <% else %>
-  action "Stopping $NAME" killproc -p "$PIDFILE" -d 10 "$NAME"
+  action "Stopping $NAME" killproc -p "$PIDFILE" -d <%= node.kafka.hard_stop_delay %> "$NAME"
   RETVAL=$?
   <% end %>
   return "$RETVAL"

--- a/templates/default/upstart/default.erb
+++ b/templates/default/upstart/default.erb
@@ -6,7 +6,7 @@ start on runlevel [2345]
 stop on runlevel [016]
 
 kill signal TERM
-kill timeout 10
+kill timeout <%= node.kafka.hard_stop_delay %>
 <% if node.kafka.ulimit_file %>
 limit nofile <%= node.kafka.ulimit_file %> <%= node.kafka.ulimit_file %>
 <% end %>


### PR DESCRIPTION
Large Kafka clusters can take much more than 10 seconds to gracefully shut down.  All the init flavors in this cookbook previously hardcoded a 10 second delay between the request for graceful stop and the hard kill of the broker.

This PR allows cookbook users to set the attribute `kafka.hard_stop_delay` to a a longer value more appropriate for their cluster.

This bit us (Whitepages) when doing a rolling upgrade under Ubuntu upstart.  The hard kill of a broker came 10 seconds after the initial stop signal and it wasn't given time to synchronize all its info before getting shot in the head by upstart; so on restart, it spent several hours re-replicating several TB of data.
