### PR TITLE
Allow KAFKA_JMX_OPTS to be configured

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,14 @@ default.kafka.config_dir = nil
 default.kafka.jmx_port = 9999
 
 #
+# JMX configuration options for Kafka.
+default.kafka.jmx_opts = %w[
+  -Dcom.sun.management.jmxremote
+  -Dcom.sun.management.jmxremote.authenticate=false
+  -Dcom.sun.management.jmxremote.ssl=false
+].join(' ')
+
+#
 # User for directories, configuration files and running Kafka.
 default.kafka.user = 'kafka'
 

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -228,6 +228,10 @@ describe 'kafka::_configure' do
         expect(chef_run).to have_configured(env_path).with('(export |)JMX_PORT').as('"9999"')
       end
 
+      it 'sets KAFKA_JMX_OPTS' do
+        expect(chef_run).to have_configured(env_path).with('(export |)KAFKA_JMX_OPTS').as('"-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"')
+      end
+
       it 'sets KAFKA_LOG4J_OPTS' do
         expect(chef_run).to have_configured(env_path).with('(export |)KAFKA_LOG4J_OPTS').as('"-Dlog4j.configuration=file:/opt/kafka/config/log4j.properties"')
       end

--- a/templates/default/env.erb
+++ b/templates/default/env.erb
@@ -7,6 +7,7 @@ export KAFKA_HEAP_OPTS="<%= node.kafka.heap_opts %>"
 export KAFKA_GC_LOG_OPTS="<%= node.kafka.gc_log_opts %>"
 export KAFKA_OPTS="<%= node.kafka.generic_opts %>"
 export KAFKA_JVM_PERFORMANCE_OPTS="<%= node.kafka.jvm_performance_opts %>"
+export KAFKA_JMX_OPTS="<%= node.kafka.jmx_opts %>"
 
 KAFKA_RUN="<%= node.kafka.install_dir %>/bin/kafka-run-class.sh"
 KAFKA_ARGS="<%= @main_class %>"

--- a/templates/default/systemd/kafka.env.erb
+++ b/templates/default/systemd/kafka.env.erb
@@ -6,6 +6,7 @@ KAFKA_HEAP_OPTS="<%= node.kafka.heap_opts %>"
 KAFKA_GC_LOG_OPTS="<%= node.kafka.gc_log_opts %>"
 KAFKA_OPTS="<%= node.kafka.generic_opts %>"
 KAFKA_JVM_PERFORMANCE_OPTS="<%= node.kafka.jvm_performance_opts %>"
+KAFKA_JMX_OPTS="<%= node.kafka.jmx_opts %>"
 
 KAFKA_RUN="<%= node.kafka.install_dir %>/bin/kafka-run-class.sh"
 KAFKA_ARGS="<%= @main_class %>"


### PR DESCRIPTION
This change adds the ability to customize the `KAFKA_JMX_OPTS` environment variable via the `default.kafka.jmx_opts` attribute. This follows the same pattern as the `KAFKA_JVM_PERFORMANCE_OPTS` variable.

I tested this locally with `kitchen test` and everything passed.

Thanks for the great cookbook and let me know if I missed anything here.