### PR TITLE
Make user creation optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,8 +65,16 @@ default.kafka.jmx_opts = %w[
 default.kafka.user = 'kafka'
 
 #
+# Shall the cookbook create the node.kafka.user
+default.kafka.manage_user = true
+
+#
 # Group for directories, configuration files and running Kafka.
 default.kafka.group = 'kafka'
+
+#
+# Shall the cookbook create the node.kafka.group
+default.kafka.manage_group = true
 
 #
 # JVM heap options for Kafka.

--- a/recipes/_setup.rb
+++ b/recipes/_setup.rb
@@ -3,12 +3,15 @@
 # Recipe:: _setup
 #
 
-group node.kafka.group
+group node.kafka.group do
+  only_if { node.kafka.manage_group }
+end
 
 user node.kafka.user do
   gid node.kafka.group
   home '/var/empty/kafka'
   shell '/sbin/nologin'
+  only_if { node.kafka.manage_user }
 end
 
 [

--- a/spec/recipes/setup_spec.rb
+++ b/spec/recipes/setup_spec.rb
@@ -27,6 +27,23 @@ describe 'kafka::_setup' do
       end
     end
 
+    context 'when disabled' do
+      let :kafka_attrs do
+        {manage_user: false, manage_group: false}
+      end
+
+      it 'does not create a kafka group' do
+        expect(chef_run).not_to create_group('kafka')
+      end
+
+      it 'does not create a kafka user' do
+        expect(chef_run).not_to create_user('kafka').with({
+          shell: '/sbin/nologin',
+          gid: 'kafka'
+        })
+      end
+    end
+
     context 'when overridden' do
       let :kafka_attrs do
         {user: 'spec', group: 'spec'}


### PR DESCRIPTION
This is a PR to make user creation optional. This addresses issue #27 for the user side.

For example, if someone has a single-sign-on (SSO) implementation defining users, then modifying shell and other attributes could be bad; e.g. see:
````
  * user[kafka] action create
================================================================================
Error executing action `create` on resource 'user[kafka]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '6'
---- Begin output of ["usermod", "-g", "80301", "-s", "/sbin/nologin", "-d", "/var/empty/kafka", "kafka"] ----
STDOUT:
STDERR: usermod: user 'kafka' does not exist in /etc/passwd
---- End output of ["usermod", "-g", "80301", "-s", "/sbin/nologin", "-d", "/var/empty/kafka", "kafka"] ----
Ran ["usermod", "-g", "80301", "-s", "/sbin/nologin", "-d", "/var/empty/kafka", "kafka"] returned 6
````

With this, one can set `create_user` to `false` and the user action will simply be skipped.

I do not see value in skipping the [`group`](https://github.com/mthssdrbrg/kafka-cookbook/blob/07cbe17c1b269b023f7f74622dab03f9b95da439/recipes/_setup.rb#L6) resource as no properties are defined. So, if the group exists it will do nothing, if the group does not exist things would blow up anyway.