### PR TITLE
Making the broker port non-mandatory for Kafka 0.9

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -58,7 +58,6 @@ template kafka_init_opts[:script_path] do
   mode kafka_init_opts[:permissions]
   variables({
     daemon_name: 'kafka',
-    port: node.kafka.broker.port,
     user: node.kafka.user,
     env_path: kafka_init_opts[:env_path],
     ulimit: node.kafka.ulimit_file,

--- a/recipes/_defaults.rb
+++ b/recipes/_defaults.rb
@@ -7,9 +7,6 @@ unless broker_attribute?(:broker, :id)
   node.default.kafka.broker.broker_id = node.ipaddress.gsub('.', '').to_i % 2**31
 end
 
-unless broker_attribute?(:port)
-  node.default.kafka.broker.port = 6667
-end
 
 unless node.kafka.gc_log_opts
   node.default.kafka.gc_log_opts = %W[

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -52,10 +52,6 @@ describe 'kafka::_configure' do
         expect(chef_run).to have_configured(path).with('broker.id').as('10002')
       end
 
-      it 'sets port' do
-        expect(chef_run).to have_configured(path).with('port').as(6667)
-      end
-
       context 'when broker id is larger than 2**31' do
         let :chef_run do
           ChefSpec::Runner.new do |node|


### PR DESCRIPTION
Hi,
  I just made this tiny change to the cookbook so that it can be used to install the bits for Kafka 0.9. If this change is merged to the original cookbook, please also make sure to mention in the Readme file that users using the updated cookbook should add the broker port in their wrapper cookbooks, if they want to install Kafka version < 0.9