### PR TITLE
Check ports open by started process

### DIFF
--- a/templates/default/partials/check_running.erb
+++ b/templates/default/partials/check_running.erb
@@ -1,10 +1,20 @@
 check_running() {
-  tries=0
-  while ( ! $(netstat --listen | grep -qE "(<%= @port %>|irc)") ); do
-    sleep 1
+  local pid="" tries=0 max_tries=5 sh="$(which sh)"
+  while [ $tries -le $max_tries ]; do
+    if [ -z "$pid" ]; then
+      if [ -e "$PIDFILE" ]; then
+        pid=$(cat "$PIDFILE")
+        check="netstat --numeric --listen --programs --tcp 2> /dev/null | grep -q '$pid/java'"
+      else
+        sleep 1
+        continue
+      fi
+    fi
+    if su -s "$sh" <%= @user %> -c "$check"; then
+      return 0
+    fi
     tries=$((tries + 1))
-
-    [ $tries -ge 5 ] && return 1
+    sleep 1
   done
-  return 0
+  return 1
 }

--- a/templates/default/sysv/debian.erb
+++ b/templates/default/sysv/debian.erb
@@ -22,7 +22,7 @@ PIDFILE=/var/run/$NAME.pid
 # Load additional configuration
 [ -f /etc/default/$NAME ] && . /etc/default/$NAME
 
-<%= render 'partials/check_running.erb', variables: {port: @port} -%>
+<%= render 'partials/check_running.erb', variables: {user: @user} -%>
 
 do_start()
 {
@@ -35,8 +35,9 @@ do_start()
   start-stop-daemon --start --quiet --chuid $USER --pidfile $PIDFILE --make-pidfile --background --exec $KAFKA_RUN -- $KAFKA_ARGS $KAFKA_CONFIG \
     || return 2
 
+  check_running
   RETVAL=$?
-  check_running && return "$RETVAL"
+  return $RETVAL
 }
 
 do_stop()
@@ -47,10 +48,10 @@ do_stop()
   while pidofproc "$PIDFILE" "$KAFKA"; do sleep 1; done
   <% else %>
   start-stop-daemon --stop --quiet --oknodo --retry=TERM/<%= @kill_timeout %>/KILL/5 --pidfile "$PIDFILE"
-  RETVAL="$?"
+  RETVAL=$?
   <% end %>
   rm -f $PIDFILE
-  return "$RETVAL"
+  return $RETVAL
 }
 
 case "$1" in
@@ -81,3 +82,5 @@ case "$1" in
     exit 3
     ;;
 esac
+
+exit $RETVAL

--- a/templates/default/sysv/default.erb
+++ b/templates/default/sysv/default.erb
@@ -24,7 +24,7 @@ RETVAL=0
 # Check that networking is up
 [ "$NETWORKING" = "no" ] && exit $RETVAL
 
-<%= render 'partials/check_running.erb', variables: {port: @port} -%>
+<%= render 'partials/check_running.erb', variables: {user: @user} -%>
 
 ensure_pid() {
   [ ! -e "$PIDFILE" ] && touch $PIDFILE && chown $USER $PIDFILE
@@ -37,7 +37,11 @@ start() {
   <% end %>
   action "Starting $NAME" daemon --user=$USER --pidfile=$PIDFILE "$NOHUP $KAFKA_RUN $KAFKA_ARGS $KAFKA_CONFIG > /dev/null 2>&1 & echo \$! > $PIDFILE"
   RETVAL=$?
-  [ $RETVAL -eq 0 ] && check_running
+  if [ $RETVAL -eq 0 ]; then
+    check_running
+    RETVAL=$?
+  fi
+  return $RETVAL
 }
 
 stop() {
@@ -63,7 +67,7 @@ stop() {
   action "Stopping $NAME" killproc -p "$PIDFILE" -d <%= @kill_timeout %> "$NAME"
   RETVAL=$?
   <% end %>
-  return "$RETVAL"
+  return $RETVAL
 }
 
 case "$1" in

--- a/templates/default/upstart/default.erb
+++ b/templates/default/upstart/default.erb
@@ -18,9 +18,17 @@ script
 end script
 
 post-start script
-  tries=0
-  while [ ! `netstat --listen | grep -qE '<%= @port %>|ircd'` ] && [ $tries -lt 3 ]; do
-    sleep 1
-    tries=$((tries + 1))
-  done
+  tries=0 max_tries=5 sh="$(which sh)"
+  pid="$(status <%= @daemon_name %> | head -1)"
+  pid=${pid##* }
+  if [ -n "$pid" ]; then
+    while [ $tries -le $max_tries ]; do
+      if netstat --numeric --listen --programs --tcp 2> /dev/null | grep -q "$pid/java"; then
+        exit 0
+      fi
+      tries=$((tries + 1))
+      sleep 1
+    done
+  fi
+  exit 1
 end script


### PR DESCRIPTION
Previously the `sysv` and `upstart` init scripts would check that *some* process was listening on the configured port, but with the `v0.9.0.0` release of Kafka it's possible to specify multiple "listeners" (not really sure why the `port` configuration parameter is still around...).

So rather than checking a specific port we check that the started process is listening to *some* port, which should sort out the issue mentioned in #91.

Fixed some minor mishaps with the SysV scripts as well. Though all of these changes should be backward compatible.

All of the init scripts are in need of an overhaul, and `systemd` doesn't even check that Kafka actually starts, nor does it support "controlled shutdown" in a similar way that `sysv` does, though this'll be handled in a separate PR.