### PR TITLE
Make `broker_id` and `port` optional

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -115,13 +115,27 @@ end
 def broker_attribute?(*parts)
   parts = parts.map(&:to_s)
   broker = node.kafka.broker
-  unless (v = broker.fetch(parts.join('.'), nil)).nil?
-    return v
+  if broker.attribute?(parts.join('.'))
+    return true
   end
-  unless (v = broker.fetch(parts.join('_'), nil)).nil?
-    return v
+  if broker.attribute?(parts.join('_'))
+    return true
   end
   key = parts.pop
   r = parts.reduce(broker) { |b, p| b.fetch(p, b) }
   r.fetch(key, nil)
+end
+
+def fetch_broker_attribute(*parts)
+  parts = parts.map(&:to_s)
+  broker = node.kafka.broker
+  if broker.attribute?(parts.join('.'))
+    return broker[parts.join('.')]
+  end
+  if broker.attribute?(parts.join('_'))
+    return broker[parts.join('_')]
+  end
+  key = parts.pop
+  r = parts.reduce(broker) { |b, p| b.fetch(p, b) }
+  r[key]
 end

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -65,7 +65,7 @@ template kafka_init_opts[:script_path] do
     kill_timeout: node.kafka.kill_timeout,
   })
   helper :controlled_shutdown_enabled? do
-    !!broker_attribute?(:controlled, :shutdown, :enable)
+    !!fetch_broker_attribute(:controlled, :shutdown, :enable)
   end
   if restart_on_configuration_change?
     notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately

--- a/spec/recipes/defaults_spec.rb
+++ b/spec/recipes/defaults_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 describe 'kafka::_defaults' do
   let :chef_run do
     r = ChefSpec::Runner.new do |node|
-      node.set.kafka.broker = attributes
+      node.set.kafka.broker = broker_attributes
     end
     r.converge(described_recipe)
   end
@@ -17,7 +17,7 @@ describe 'kafka::_defaults' do
 
   context 'broker id' do
     context 'when set using Property string notation' do
-      let :attributes do
+      let :broker_attributes do
         {'broker.id' => 'set'}
       end
 
@@ -32,7 +32,7 @@ describe 'kafka::_defaults' do
     end
 
     context 'when set using nested hash notation' do
-      let :attributes do
+      let :broker_attributes do
         {broker: {id: 'set'}}
       end
 
@@ -47,7 +47,7 @@ describe 'kafka::_defaults' do
     end
 
     context 'when set using underscore notation' do
-      let :attributes do
+      let :broker_attributes do
         {broker_id: 'set'}
       end
 
@@ -60,15 +60,57 @@ describe 'kafka::_defaults' do
         expect { node.kafka.broker.broker.id }.to raise_error(NoMethodError)
       end
     end
+
+    context 'when set to `nil`' do
+      let :broker_attributes do
+        {broker_id: nil}
+      end
+
+      it 'does not override it' do
+        expect(node.kafka.broker.broker_id).to be_nil
+      end
+    end
+
+    context 'when not set' do
+      let :broker_attributes do
+        {}
+      end
+
+      it 'does override it' do
+        expect(node.kafka.broker.broker_id).to_not be_nil
+      end
+    end
   end
 
   context 'port' do
-    let :attributes do
-      {port: 9093}
+    context 'when set' do
+      let :broker_attributes do
+        {port: 9093}
+      end
+
+      it 'does not override it' do
+        expect(node.kafka.broker.port).to eq(9093)
+      end
     end
 
-    it 'does not override it' do
-      expect(node.kafka.broker.port).to eq(9093)
+    context 'when set to `nil`' do
+      let :broker_attributes do
+        {port: nil}
+      end
+
+      it 'does not override it' do
+        expect(node.kafka.broker.port).to be_nil
+      end
+    end
+
+    context 'when not set' do
+      let :broker_attributes do
+        {}
+      end
+
+      it 'does override it' do
+        expect(node.kafka.broker.port).to eq(6667)
+      end
     end
   end
 end


### PR DESCRIPTION
Seems as if the configuration has changed a bit with Kafka `v0.9.0.0` with regards to broker IDs (now possible to have them auto-generated) and what port to use (if I understand it correctly one can now specify multiple "listeners").

The changes in this pull request makes it possible to set both `broker_id` and `port` to `nil` to avoid them from being rendered in the configuration file at all. If the attributes aren't set to `nil` the previous behaviour (as can be seen in the `_defaults` recipe) will still hold, i.e. `broker_id` will be "generated" from the node's IP address and the `port` will be set to `6667`.