### PR TITLE
Explicit format for broker configuration

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -20,13 +20,9 @@ provisioner:
       md5_checksum: <%= ENV.fetch('KAFKA_MD5', '').inspect %>
       ulimit_file: 128000
       broker:
-        broker:
-          id: 1
-        controlled:
-          shutdown:
-            enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
-        log:
-          dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
+        broker.id: 1
+        controlled.shutdown.enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
+        log.dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
         zookeeper.connect: ['localhost:2181']
       log4j:
         appenders:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,14 +28,10 @@ provisioner:
       md5_checksum: <%= ENV.fetch('KAFKA_MD5', '').inspect %>
       ulimit_file: 128000
       broker:
-        broker:
-          id: 1
-        controlled:
-          shutdown:
-            enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
-        log:
-          dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
-        zookeeper_connect: ['localhost:2181']
+        broker.id: 1
+        controlled.shutdown.enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
+        log.dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
+        zookeeper.connect: ['localhost:2181']
       log4j:
         appenders:
           zookeeperAppender:

--- a/libraries/configuration.rb
+++ b/libraries/configuration.rb
@@ -18,26 +18,15 @@ module Kafka
       end
     end
 
-    def render_option(prefix, value)
-      prefix = convert_key(prefix)
-      case value
-      when Hash
-        lines = value.map do |key, val|
-          render_option(%(#{prefix}.#{key}), val)
-        end
-        lines.join($/)
-      when Array
-        %(#{prefix}=#{render_array_value(value)})
+    def render_option(key, value)
+      if value.is_a?(Array)
+        %(#{key}=#{render_array_value(value)})
       else
-        %(#{prefix}=#{value})
+        %(#{key}=#{value})
       end
     end
 
     private
-
-    def convert_key(key)
-      key.include?('.') ? key : key.tr('_', '.')
-    end
 
     def render_array_value(values)
       vvs = values.flat_map do |v|

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -67,20 +67,6 @@ describe 'kafka::_configure' do
       end
     end
 
-    context 'configuration using underscore notation' do
-      it_behaves_correctly 'when value is an Array' do
-        let :broker_attributes do
-          { 'array_option' => mappings }
-        end
-      end
-
-      it_behaves_correctly 'when configuration name contains both `_` and `.`' do
-        let :broker_attributes do
-          { 'possible.future_option' => mappings }
-        end
-      end
-    end
-
     context 'configuration using dotted String notation' do
       it_behaves_correctly 'when value is an Array' do
         let :broker_attributes do
@@ -91,20 +77,6 @@ describe 'kafka::_configure' do
       it_behaves_correctly 'when configuration name contains both `_` and `.`' do
         let :broker_attributes do
           { 'possible.future_option' => mappings }
-        end
-      end
-    end
-
-    context 'configuration using nested Hashes notation' do
-      it_behaves_correctly 'when value is an Array' do
-        let :broker_attributes do
-          { 'array' => { 'option' => mappings } }
-        end
-      end
-
-      it_behaves_correctly 'when configuration name contains both `_` and `.`' do
-        let :broker_attributes do
-          { 'possible' => { 'future_option' => mappings } }
         end
       end
     end


### PR DESCRIPTION
As stated in the README, it's currently possible to set the `broker` attributes in a couple of different ways and still have the configuration file rendered correctly:

``` ruby
node.default.kafka.broker[:log_dirs] = %w[/tmp/kafka-logs]
node.default.kafka.broker['log.dirs'] = %w[/tmp/kafka-logs]
node.default.kafka.broker.log.dirs = %w[/tmp/kafka-logs]
node.default[:kafka][:broker][:log][:dirs] = %w[/tmp/kafka-logs]
```

It's however not without it's flaws, as the "dotted" notation (`node.default.kafka.broker.log.dirs`) breaks down for some options (`default.replication.factor`, etc). The underscore notation only works as long as there aren't any options that actually include an underscore, though currently all of them are using `.` as a separator, it would be possible for metrics reporters and whatnot to add configuration options that include underscores.

So my proposal is to only allow explicit string keys, i.e.:

``` ruby
node.default.kafka.broker['log.dirs'] = %w[/tmp/kafka-logs]
node.default[:kafka][:broker]['log.dirs'] = %w[/tmp/kafka-logs]
```

Perhaps not the most appealing syntax, but it should be more future proof than the alternatives (or at least I hope so). Comments/suggestions/improvements are welcome.
