### PR TITLE
Release to Chef Supermarket

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'rake'
+  gem 'stove'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
       pry (~> 0.9)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
+    chef-api (0.5.0)
+      logify (~> 0.1)
+      mime-types
     chef-zero (2.0.2)
       hashie (~> 2.0)
       json
@@ -95,6 +98,7 @@ GEM
       test-kitchen (>= 1.0.0)
     kitchen-vagrant (0.18.0)
       test-kitchen (~> 1.4)
+    logify (0.2.0)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.1)
@@ -179,6 +183,9 @@ GEM
     solve (1.2.0)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
+    stove (3.2.8)
+      chef-api (~> 0.5)
+      logify (~> 0.2)
     systemu (2.5.2)
     test-kitchen (1.4.2)
       mixlib-shellout (>= 1.2, < 3.0)
@@ -207,6 +214,7 @@ DEPENDENCIES
   kitchen-docker
   kitchen-vagrant
   rake
+  stove
   test-kitchen
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 [![Build Status](https://travis-ci.org/mthssdrbrg/kafka-cookbook.svg?branch=master)](https://travis-ci.org/mthssdrbrg/kafka-cookbook)
 [![GitHub Release](https://img.shields.io/github/release/mthssdrbrg/kafka-cookbook.svg)]()
 
+> Note: if you're reading this on Supermarket, version `< 2` refers to [Webtrends/kafka](https://github.com/Webtrends/kafka)
+> cookbook while version `>= 2` refers to [mthssdrbrg/kafka-cookbook](https://github.com/mthssdrbrg/kafka-cookbook).
+
 Installs and configures Kafka `>= v0.8.1`.
 
-Based on the Kafka cookbook released by WebTrends (thanks!), but with a few
+Initially based on the Kafka cookbook released by Webtrends (thanks!), but with a few
 notable differences:
 
 * does not depend on runit cookbook.

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require 'rspec/core/rake_task'
 require 'foodcritic'
 require 'stove'
+require 'stove/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 FoodCritic::Rake::LintTask.new
@@ -30,6 +31,11 @@ task :package => :test do
     end
     puts %(Created archive of #{version} as #{archive_path})
   end
+end
+
+Stove::RakeTask.new do |t|
+  t.stove_opts = %w[--no-git]
+  t.log_level = :debug
 end
 
 class KitchenTask

--- a/gemfiles/chef-11.10.4/Gemfile
+++ b/gemfiles/chef-11.10.4/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
+  gem 'stove'
   gem 'foodcritic', '< 5'
   gem 'berkshelf', '< 4'
   gem 'chef', '= 11.10.4'

--- a/gemfiles/chef-11.10.4/Gemfile.lock
+++ b/gemfiles/chef-11.10.4/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       puma (~> 1.6)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
+    chef-api (0.5.0)
+      logify (~> 0.1)
+      mime-types
     chef-zero (1.7.3)
       hashie (~> 2.0)
       json
@@ -89,6 +92,7 @@ GEM
     hitimes (1.2.1)
     ipaddress (0.8.0)
     json (1.8.1)
+    logify (0.2.0)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.1)
@@ -168,6 +172,9 @@ GEM
     solve (1.2.0)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
+    stove (3.2.8)
+      chef-api (~> 0.5)
+      logify (~> 0.2)
     systemu (2.5.2)
     thor (0.19.1)
     timers (3.0.1)
@@ -189,6 +196,7 @@ DEPENDENCIES
   foodcritic (< 5)
   rake
   rspec (= 2.14.1)
+  stove
 
 BUNDLED WITH
    1.10.6

--- a/gemfiles/chef-11.4.4/Gemfile
+++ b/gemfiles/chef-11.4.4/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
+  gem 'stove'
   gem 'foodcritic', '< 5'
   gem 'berkshelf', '< 4'
   gem 'chef', '= 11.4.4'

--- a/gemfiles/chef-11.4.4/Gemfile.lock
+++ b/gemfiles/chef-11.4.4/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       ohai (>= 0.6.0)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
+    chef-api (0.5.0)
+      logify (~> 0.1)
+      mime-types
     chefspec (3.4.0)
       chef (~> 11.0)
       fauxhai (~> 2.0)
@@ -77,6 +80,7 @@ GEM
     hitimes (1.2.1)
     ipaddress (0.8.0)
     json (1.7.7)
+    logify (0.2.0)
     mime-types (1.25.1)
     mini_portile (0.6.1)
     minitar (0.5.4)
@@ -147,6 +151,9 @@ GEM
     solve (1.2.0)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
+    stove (3.2.8)
+      chef-api (~> 0.5)
+      logify (~> 0.2)
     systemu (2.5.2)
     thor (0.19.1)
     timers (3.0.1)
@@ -168,6 +175,7 @@ DEPENDENCIES
   foodcritic (< 5)
   rake
   rspec (= 2.14.1)
+  stove
 
 BUNDLED WITH
    1.10.6

--- a/gemfiles/chef-11.6.2/Gemfile
+++ b/gemfiles/chef-11.6.2/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
+  gem 'stove'
   gem 'foodcritic', '< 5'
   gem 'berkshelf', '< 4'
   gem 'chef', '= 11.6.2'

--- a/gemfiles/chef-11.6.2/Gemfile.lock
+++ b/gemfiles/chef-11.6.2/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       ohai (>= 0.6.0, < 7.0.0)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
+    chef-api (0.5.0)
+      logify (~> 0.1)
+      mime-types
     chefspec (3.4.0)
       chef (~> 11.0)
       fauxhai (~> 2.0)
@@ -77,6 +80,7 @@ GEM
     hitimes (1.2.1)
     ipaddress (0.8.0)
     json (1.7.7)
+    logify (0.2.0)
     mime-types (1.25.1)
     mini_portile (0.6.1)
     minitar (0.5.4)
@@ -146,6 +150,9 @@ GEM
     solve (1.2.0)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
+    stove (3.2.8)
+      chef-api (~> 0.5)
+      logify (~> 0.2)
     systemu (2.5.2)
     thor (0.19.1)
     timers (3.0.1)
@@ -167,6 +174,7 @@ DEPENDENCIES
   foodcritic (< 5)
   rake
   rspec (= 2.14.1)
+  stove
 
 BUNDLED WITH
    1.10.6

--- a/gemfiles/chef-11.8.2/Gemfile
+++ b/gemfiles/chef-11.8.2/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
+  gem 'stove'
   gem 'foodcritic', '< 5'
   gem 'berkshelf', '< 4'
   gem 'chef', '= 11.8.2'

--- a/gemfiles/chef-11.8.2/Gemfile.lock
+++ b/gemfiles/chef-11.8.2/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       puma (~> 1.6)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
+    chef-api (0.5.0)
+      logify (~> 0.1)
+      mime-types
     chef-zero (1.7.3)
       hashie (~> 2.0)
       json
@@ -89,6 +92,7 @@ GEM
     hitimes (1.2.1)
     ipaddress (0.8.0)
     json (1.7.7)
+    logify (0.2.0)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.1)
@@ -168,6 +172,9 @@ GEM
     solve (1.2.0)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
+    stove (3.2.8)
+      chef-api (~> 0.5)
+      logify (~> 0.2)
     systemu (2.5.2)
     thor (0.19.1)
     timers (3.0.1)
@@ -189,6 +196,7 @@ DEPENDENCIES
   foodcritic (< 5)
   rake
   rspec (= 2.14.1)
+  stove
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
This pull request adds a `publish` Rake task using `Stove` for releasing the cookbook to Chef's Supermarket, as discussed in #93.