### PR TITLE
Fixup optional broker configuration

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -14,9 +14,13 @@ provisioner:
       md5_checksum: <%= ENV.fetch('KAFKA_MD5', '').inspect %>
       ulimit_file: 128000
       broker:
-        broker.id: 1
-        controlled.shutdown.enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
-        log.dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
+        broker:
+          id: 1
+        controlled:
+          shutdown:
+            enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
+        log:
+          dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
         zookeeper.connect: ['localhost:2181']
       log4j:
         appenders:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,10 +26,14 @@ provisioner:
       md5_checksum: <%= ENV.fetch('KAFKA_MD5', '').inspect %>
       ulimit_file: 128000
       broker:
-        broker.id: 1
-        controlled.shutdown.enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
-        log.dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
-        zookeeper.connect: ['localhost:2181']
+        broker:
+          id: 1
+        controlled:
+          shutdown:
+            enable: <%= ENV.fetch('KAFKA_CTRL_SHUTDOWN', false) %>
+        log:
+          dirs: ['/mnt/kafka-logs-1', '/mnt/kafka-logs-2']
+        zookeeper_connect: ['localhost:2181']
       log4j:
         appenders:
           zookeeperAppender:

--- a/libraries/configuration.rb
+++ b/libraries/configuration.rb
@@ -5,6 +5,19 @@
 
 module Kafka
   module Configuration
+    def render_option?(value)
+      case value
+      when Hash
+        value.values.all? do |v|
+          render_option?(v)
+        end
+      when Array
+        !value.empty?
+      else
+        !value.nil?
+      end
+    end
+
     def render_option(prefix, value)
       prefix = convert_key(prefix)
       case value

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -106,7 +106,7 @@ def broker_attribute?(*parts)
   end
   key = parts.pop
   r = parts.reduce(broker) { |b, p| b.fetch(p, b) }
-  r.fetch(key, nil)
+  r.attribute?(key)
 end
 
 def fetch_broker_attribute(*parts)

--- a/spec/recipes/defaults_spec.rb
+++ b/spec/recipes/defaults_spec.rb
@@ -63,11 +63,11 @@ describe 'kafka::_defaults' do
 
     context 'when set to `nil`' do
       let :broker_attributes do
-        {broker_id: nil}
+        {broker: {id: nil}}
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker.broker_id).to be_nil
+        expect(node.kafka.broker['broker']['id']).to be_nil
       end
     end
 

--- a/templates/default/server.properties.erb
+++ b/templates/default/server.properties.erb
@@ -2,7 +2,7 @@
 # Local modifications will be overwritten.
 
 <% @config.each do |key, value| %>
-<%   unless value.nil? %>
+<%   if render_option?(value) %>
 <%=    render_option(key, value) %>
 <%   end %>
 <% end %>


### PR DESCRIPTION
The previous solution didn't work properly when using the nested hash notation for setting broker configuration, which is one of the reasons why I want to get rid of it.

This ought to do it though.