### PR TITLE
Switch to bracket syntax for node attributes

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -46,8 +46,7 @@ platforms:
   - name: debian-7.4
     driver_config:
       provision_command:
-        - apt-get install -y openjdk-7-jre-headless
-        - apt-get install -y net-tools
+        - apt-get install -y openjdk-7-jre-headless net-tools
         - curl -L https://chef.io/chef/install.sh | bash -s -- -v <%= ENV.fetch('CHEF_VERSION', '11.16.4') %>
   - name: ubuntu-14.04
     driver_config:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ keep a lot file handles open due to socket connections (depends on the number of
 brokers, producers and consumers) and the actual data log files (depends on
 the number of partitions and log segment and/or log roll settings).
 
-It's possible to set a specific `ulimit` for Kafka using the `node.kafka.ulimit_file`
+It's possible to set a specific `ulimit` for Kafka using the `node['kafka']['ulimit_file']`
 attribute.
 If this value is not set, Kafka will use whatever the system default is, which
 as stated previously might not be enough, so it might be wise to set a higher
@@ -166,19 +166,19 @@ that needs to be set (assumes that you have ZooKeeper running on port 2181
 locally):
 
 ```ruby
-node.default.kafka.broker.zookeeper.connect = 'localhost:2181'
+node.default['kafka']['broker]['zookeeper.connect'] = 'localhost:2181'
 # This shouldn't normally be necessary, but might need to be set explicitly
 # if you're having trouble connecting to the brokers.
-node.default.kafka.broker.hostname = '127.0.0.1' # or perhaps 'localhost'
+node.default['kafka']['broker']['hostname'] = '127.0.0.1' # or perhaps 'localhost'
 ```
 
 If you plan on running a cluster locally you will want to set separate
 values for the following configuration options:
 
 ```ruby
-node.default.kafka.broker.broker.id = <id>
-node.default.kafka.broker.port = <port>
-node.default.kafka.broker.log.dirs = <dir path>
+node.default['kafka']['broker']['broker.id'] = <id>
+node.default['kafka']['broker']['port'] = <port>
+node.default['kafka']['broker']['log.dirs'] = <dir path>
 ```
 
 Other than that things should work as expected, though depending on what

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,56 +5,56 @@
 
 #
 # Version of Kafka to install.
-default.kafka.version = '0.8.1.1'
+default['kafka']['version'] = '0.8.1.1'
 
 #
 # Base URL for Kafka releases. The recipes will a download URL using the
 # `base_url`, `version` and `scala_version` attributes.
-default.kafka.base_url = 'https://archive.apache.org/dist/kafka'
+default['kafka']['base_url'] = 'https://archive.apache.org/dist/kafka'
 
 #
 # SHA-256 checksum of the archive to download, used by Chef's `remote_file`
 # resource.
-default.kafka.checksum = 'cb141c1d50b1bd0d741d68e5e21c090341d961cd801e11e42fb693fa53e9aaed'
+default['kafka']['checksum'] = 'cb141c1d50b1bd0d741d68e5e21c090341d961cd801e11e42fb693fa53e9aaed'
 
 #
 # MD5 checksum of the archive to download, which will be used to validate that
 # the "correct" archive has been downloaded.
-default.kafka.md5_checksum = '7541ed160f1b3aa1a5334d4e782ba4d3'
+default['kafka']['md5_checksum'] = '7541ed160f1b3aa1a5334d4e782ba4d3'
 
 #
 # Scala version of Kafka.
-default.kafka.scala_version = '2.9.2'
+default['kafka']['scala_version'] = '2.9.2'
 
 #
 # Directory where to install Kafka.
-default.kafka.install_dir = '/opt/kafka'
+default['kafka']['install_dir'] = '/opt/kafka'
 
 #
 # Directory where to install *this* version of Kafka.
 # For actual default value see `_defaults` recipe.
-default.kafka.version_install_dir = nil
+default['kafka']['version_install_dir'] = nil
 
 #
 # Directory where the downloaded archive will be extracted to.
-default.kafka.build_dir = ::File.join(Dir.tmpdir, 'kafka-build')
+default['kafka']['build_dir'] = ::File.join(Dir.tmpdir, 'kafka-build')
 
 #
 # Directory where to store logs from Kafka.
-default.kafka.log_dir = '/var/log/kafka'
+default['kafka']['log_dir'] = '/var/log/kafka'
 
 #
 # Directory where to keep Kafka configuration files. For the
 # actual default value see `_defaults` recipe.
-default.kafka.config_dir = nil
+default['kafka']['config_dir'] = nil
 
 #
 # JMX port for Kafka.
-default.kafka.jmx_port = 9999
+default['kafka']['jmx_port'] = 9999
 
 #
 # JMX configuration options for Kafka.
-default.kafka.jmx_opts = %w[
+default['kafka']['jmx_opts'] = %w[
   -Dcom.sun.management.jmxremote
   -Dcom.sun.management.jmxremote.authenticate=false
   -Dcom.sun.management.jmxremote.ssl=false
@@ -62,32 +62,32 @@ default.kafka.jmx_opts = %w[
 
 #
 # User for directories, configuration files and running Kafka.
-default.kafka.user = 'kafka'
+default['kafka']['user'] = 'kafka'
 
 #
-# Should node.kafka.user and node.kafka.group be created?
-default.kafka.manage_user = true
+# Should node['kafka']['user'] and node['kafka']['group'] be created?
+default['kafka']['manage_user'] = true
 
 #
 # Group for directories, configuration files and running Kafka.
-default.kafka.group = 'kafka'
+default['kafka']['group'] = 'kafka'
 
 #
 # JVM heap options for Kafka.
-default.kafka.heap_opts = '-Xmx1G -Xms1G'
+default['kafka']['heap_opts'] = '-Xmx1G -Xms1G'
 
 #
 # Generic JVM options for Kafka.
-default.kafka.generic_opts = nil
+default['kafka']['generic_opts'] = nil
 
 #
 # GC log options for Kafka. For the actual default value
 # see `_defaults` recipe.
-default.kafka.gc_log_opts = nil
+default['kafka']['gc_log_opts'] = nil
 
 #
 # JVM Performance options for Kafka.
-default.kafka.jvm_performance_opts = %w[
+default['kafka']['jvm_performance_opts'] = %w[
   -server
   -XX:+UseCompressedOops
   -XX:+UseParNewGC
@@ -101,7 +101,7 @@ default.kafka.jvm_performance_opts = %w[
 #
 # The type of "init" system to install scripts for. Valid values are currently
 # :sysv, :systemd and :upstart.
-default.kafka.init_style = :sysv
+default['kafka']['init_style'] = :sysv
 
 #
 # The ulimit file limit.
@@ -110,11 +110,11 @@ default.kafka.init_style = :sysv
 # value, or you will most likely run into issues with Kafka simply dying for no
 # particular reason as it needs to keep a lot of file handles for socket
 # connections and log files for all partitions.
-default.kafka.ulimit_file = nil
+default['kafka']['ulimit_file'] = nil
 
 #
 # Automatically start kafka service.
-default.kafka.automatic_start = false
+default['kafka']['automatic_start'] = false
 
 #
 # Automatically restart kafka on configuration change.
@@ -122,36 +122,36 @@ default.kafka.automatic_start = false
 # The reason for this is that I can see the need for automatically starting
 # Kafka if it's not running, but not necessarily restart on configuration
 # changes.
-default.kafka.automatic_restart = false
+default['kafka']['automatic_restart'] = false
 
 #
 # Attribute to set the recipe to used to coordinate Kafka service start
 # if nothing is set the default recipe "_coordinate" will be used
 # Refer to issue #58 for details.
-default.kafka.start_coordination.recipe = 'kafka::_coordinate'
+default['kafka']['start_coordination']['recipe'] = 'kafka::_coordinate'
 
 #
 # Attribute to set the timeout in seconds when stopping the broker
 # before sending SIGKILL (or equivalent).
-default.kafka.kill_timeout = 10
+default['kafka']['kill_timeout'] = 10
 
 #
 # `broker` namespace for configuration of a broker.
 # Initially set to an empty Hash to avoid having `fetch(:broker, {})`
 # statements in helper methods and the alike.
-default.kafka.broker = {}
+default['kafka']['broker'] = {}
 
 #
 # Root logger level and appender.
-default.kafka.log4j.root_logger = 'INFO, kafkaAppender'
+default['kafka']['log4j']['root_logger'] = 'INFO, kafkaAppender'
 
 #
 # Appender definitions for various Kafka classes.
-default.kafka.log4j.appenders = {
+default['kafka']['log4j']['appenders'] = {
   'kafkaAppender' => {
     type: 'org.apache.log4j.DailyRollingFileAppender',
     date_pattern: '.yyyy-MM-dd',
-    file: lazy { ::File.join(node.kafka.log_dir, 'kafka.log') },
+    file: lazy { ::File.join(node['kafka']['log_dir'], 'kafka.log') },
     layout: {
       type: 'org.apache.log4j.PatternLayout',
       conversion_pattern: '[%d] %p %m (%c)%n',
@@ -160,7 +160,7 @@ default.kafka.log4j.appenders = {
   'stateChangeAppender' => {
     type: 'org.apache.log4j.DailyRollingFileAppender',
     date_pattern: '.yyyy-MM-dd',
-    file: lazy { ::File.join(node.kafka.log_dir, 'kafka-state-change.log') },
+    file: lazy { ::File.join(node['kafka']['log_dir'], 'kafka-state-change.log') },
     layout: {
       type: 'org.apache.log4j.PatternLayout',
       conversion_pattern: '[%d] %p %m (%c)%n',
@@ -169,7 +169,7 @@ default.kafka.log4j.appenders = {
   'requestAppender' => {
     type: 'org.apache.log4j.DailyRollingFileAppender',
     date_pattern: '.yyyy-MM-dd',
-    file: lazy { ::File.join(node.kafka.log_dir, 'kafka-request.log') },
+    file: lazy { ::File.join(node['kafka']['log_dir'], 'kafka-request.log') },
     layout: {
       type: 'org.apache.log4j.PatternLayout',
       conversion_pattern: '[%d] %p %m (%c)%n',
@@ -178,7 +178,7 @@ default.kafka.log4j.appenders = {
   'controllerAppender' => {
     type: 'org.apache.log4j.DailyRollingFileAppender',
     date_pattern: '.yyyy-MM-dd',
-    file: lazy { ::File.join(node.kafka.log_dir, 'kafka-controller.log') },
+    file: lazy { ::File.join(node['kafka']['log_dir'], 'kafka-controller.log') },
     layout: {
       type: 'org.apache.log4j.PatternLayout',
       conversion_pattern: '[%d] %p %m (%c)%n',
@@ -188,7 +188,7 @@ default.kafka.log4j.appenders = {
 
 #
 # Logger definitions.
-default.kafka.log4j.loggers = {
+default['kafka']['log4j']['loggers'] = {
   'org.IOItec.zkclient.ZkClient' => {
     level: 'INFO',
   },

--- a/libraries/env_file.rb
+++ b/libraries/env_file.rb
@@ -11,7 +11,7 @@ module Kafka
     end
 
     def export?
-      node.kafka.init_style.to_sym != :systemd
+      node['kafka']['init_style'].to_sym != :systemd
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,7 +4,7 @@
 #
 
 def kafka_base
-  %(kafka_#{node.kafka.scala_version}-#{node.kafka.version})
+  %(kafka_#{node['kafka']['scala_version']}-#{node['kafka']['version']})
 end
 
 def kafka_tar_gz
@@ -16,23 +16,23 @@ def kafka_local_download_path
 end
 
 def kafka_target_path
-  ::File.join(node.kafka.build_dir, kafka_base)
+  ::File.join(node['kafka']['build_dir'], kafka_base)
 end
 
 def kafka_jar_path
-  ::File.join(node.kafka.install_dir, 'libs', %(#{kafka_base}.jar))
+  ::File.join(node['kafka']['install_dir'], 'libs', %(#{kafka_base}.jar))
 end
 
 def kafka_installed?
-  ::File.exists?(node.kafka.install_dir) && ::File.exists?(kafka_jar_path)
+  ::File.exists?(node['kafka']['install_dir']) && ::File.exists?(kafka_jar_path)
 end
 
 def kafka_download_uri(filename)
-  [node.kafka.base_url, node.kafka.version, filename].join('/')
+  [node['kafka']['base_url'], node['kafka']['version'], filename].join('/')
 end
 
 def kafka_init_style
-  node.kafka.init_style.to_sym
+  node['kafka']['init_style'].to_sym
 end
 
 def kafka_init_opts
@@ -73,11 +73,11 @@ def kafka_init_opts
 end
 
 def start_automatically?
-  !!node.kafka.automatic_start || restart_on_configuration_change?
+  !!node['kafka']['automatic_start'] || restart_on_configuration_change?
 end
 
 def restart_on_configuration_change?
-  !!node.kafka.automatic_restart
+  !!node['kafka']['automatic_restart']
 end
 
 def kafka_service_actions
@@ -88,16 +88,16 @@ end
 
 def kafka_log_dirs
   dirs = []
-  dirs += Array(node.kafka.broker['log.dirs'])
-  dirs += Array(node.kafka.broker.fetch(:log_dirs, []))
-  dirs += Array(node.kafka.broker.fetch(:log, {}).fetch(:dirs, []))
+  dirs += Array(node['kafka']['broker']['log.dirs'])
+  dirs += Array(node['kafka']['broker'].fetch(:log_dirs, []))
+  dirs += Array(node['kafka']['broker'].fetch(:log, {}).fetch(:dirs, []))
   dirs.uniq!
   dirs
 end
 
 def broker_attribute?(*parts)
   parts = parts.map(&:to_s)
-  broker = node.kafka.broker
+  broker = node['kafka']['broker']
   if broker.attribute?(parts.join('.'))
     return true
   end
@@ -111,7 +111,7 @@ end
 
 def fetch_broker_attribute(*parts)
   parts = parts.map(&:to_s)
-  broker = node.kafka.broker
+  broker = node['kafka']['broker']
   if broker.attribute?(parts.join('.'))
     return broker[parts.join('.')]
   end

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -14,10 +14,10 @@ action :run do
     command %(rm -rf #{new_resource.from})
   end
 
-  link node.kafka.install_dir do
-    owner node.kafka.user
-    group node.kafka.group
-    to node.kafka.version_install_dir
+  link node['kafka']['install_dir'] do
+    owner node['kafka']['user']
+    group node['kafka']['group']
+    to node['kafka']['version_install_dir']
   end
 
   new_resource.updated_by_last_action(true)

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -3,32 +3,32 @@
 # Recipe:: _configure
 #
 
-directory node.kafka.config_dir do
-  owner node.kafka.user
-  group node.kafka.group
+directory node['kafka']['config_dir'] do
+  owner node['kafka']['user']
+  group node['kafka']['group']
   mode '755'
   recursive true
 end
 
-template ::File.join(node.kafka.config_dir, 'log4j.properties') do
+template ::File.join(node['kafka']['config_dir'], 'log4j.properties') do
   source 'log4j.properties.erb'
-  owner node.kafka.user
-  group node.kafka.group
+  owner node['kafka']['user']
+  group node['kafka']['group']
   mode '644'
   helpers(Kafka::Log4J)
-  variables(config: node.kafka.log4j)
+  variables(config: node['kafka']['log4j'])
   if restart_on_configuration_change?
     notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
 end
 
-template ::File.join(node.kafka.config_dir, 'server.properties') do
+template ::File.join(node['kafka']['config_dir'], 'server.properties') do
   source 'server.properties.erb'
-  owner node.kafka.user
-  group node.kafka.group
+  owner node['kafka']['user']
+  group node['kafka']['group']
   mode '644'
   helpers(Kafka::Configuration)
-  variables(config: node.kafka.broker.sort_by(&:first))
+  variables(config: node['kafka']['broker'].sort_by(&:first))
   if restart_on_configuration_change?
     notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
@@ -52,11 +52,11 @@ template kafka_init_opts[:script_path] do
   mode kafka_init_opts[:permissions]
   variables({
     daemon_name: 'kafka',
-    port: node.kafka.broker.port,
-    user: node.kafka.user,
+    port: node['kafka']['broker']['port'],
+    user: node['kafka']['user'],
     env_path: kafka_init_opts[:env_path],
-    ulimit: node.kafka.ulimit_file,
-    kill_timeout: node.kafka.kill_timeout,
+    ulimit: node['kafka']['ulimit_file'],
+    kill_timeout: node['kafka']['kill_timeout'],
   })
   helper :controlled_shutdown_enabled? do
     !!fetch_broker_attribute(:controlled, :shutdown, :enable)
@@ -66,4 +66,4 @@ template kafka_init_opts[:script_path] do
   end
 end
 
-include_recipe node.kafka.start_coordination.recipe
+include_recipe node['kafka']['start_coordination']['recipe']

--- a/recipes/_defaults.rb
+++ b/recipes/_defaults.rb
@@ -4,25 +4,25 @@
 #
 
 unless broker_attribute?(:broker, :id)
-  node.default.kafka.broker.broker_id = node.ipaddress.gsub('.', '').to_i % 2**31
+  node.default['kafka']['broker']['broker_id'] = node['ipaddress'].gsub('.', '').to_i % 2**31
 end
 
 unless broker_attribute?(:port)
-  node.default.kafka.broker.port = 6667
+  node.default['kafka']['broker']['port'] = 6667
 end
 
-unless node.kafka.gc_log_opts
-  node.default.kafka.gc_log_opts = %W[
-    -Xloggc:#{::File.join(node.kafka.log_dir, 'kafka-gc.log')}
+unless node['kafka']['gc_log_opts']
+  node.default['kafka']['gc_log_opts'] = %W[
+    -Xloggc:#{::File.join(node['kafka']['log_dir'], 'kafka-gc.log')}
     -XX:+PrintGCDateStamps
     -XX:+PrintGCTimeStamps
   ].join(' ')
 end
 
-unless node.kafka.config_dir
-  node.default.kafka.config_dir = ::File.join(node.kafka.install_dir, 'config')
+unless node['kafka']['config_dir']
+  node.default['kafka']['config_dir'] = ::File.join(node['kafka']['install_dir'], 'config')
 end
 
-unless node.kafka.version_install_dir
-  node.default.kafka.version_install_dir = %(#{node.kafka.install_dir}-#{node.kafka.version})
+unless node['kafka']['version_install_dir']
+  node.default['kafka']['version_install_dir'] = %(#{node['kafka']['install_dir']}-#{node['kafka']['version']})
 end

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -5,21 +5,21 @@
 
 kafka_download kafka_local_download_path do
   source kafka_download_uri(kafka_tar_gz)
-  checksum node.kafka.checksum
-  md5_checksum node.kafka.md5_checksum
+  checksum node['kafka']['checksum']
+  md5_checksum node['kafka']['md5_checksum']
   not_if { kafka_installed? }
 end
 
 execute 'extract-kafka' do
-  cwd node.kafka.build_dir
+  cwd node['kafka']['build_dir']
   command <<-EOH.gsub(/^\s+/, '')
     tar zxf #{kafka_local_download_path} && \
-    chown -R #{node.kafka.user}:#{node.kafka.group} #{node.kafka.build_dir}
+    chown -R #{node['kafka']['user']}:#{node['kafka']['group']} #{node['kafka']['build_dir']}
   EOH
   not_if { kafka_installed? }
 end
 
-kafka_install node.kafka.version_install_dir do
+kafka_install node['kafka']['version_install_dir'] do
   from kafka_target_path
   not_if { kafka_installed? }
 end

--- a/recipes/_setup.rb
+++ b/recipes/_setup.rb
@@ -3,25 +3,25 @@
 # Recipe:: _setup
 #
 
-group node.kafka.group do
-  only_if { node.kafka.manage_user }
+group node['kafka']['group'] do
+  only_if { node['kafka']['manage_user'] }
 end
 
-user node.kafka.user do
-  gid node.kafka.group
+user node['kafka']['user'] do
+  gid node['kafka']['group']
   home '/var/empty/kafka'
   shell '/sbin/nologin'
-  only_if { node.kafka.manage_user }
+  only_if { node['kafka']['manage_user'] }
 end
 
 [
-  node.kafka.version_install_dir,
-  node.kafka.log_dir,
-  node.kafka.build_dir,
+  node['kafka']['version_install_dir'],
+  node['kafka']['log_dir'],
+  node['kafka']['build_dir'],
 ].each do |dir|
   directory dir do
-    owner node.kafka.user
-    group node.kafka.group
+    owner node['kafka']['user']
+    group node['kafka']['group']
     mode '755'
     recursive true
   end
@@ -29,8 +29,8 @@ end
 
 kafka_log_dirs.each do |dir|
   directory dir do
-    owner node.kafka.user
-    group node.kafka.group
+    owner node['kafka']['user']
+    group node['kafka']['group']
     mode '755'
     recursive true
   end

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe 'kafka::_configure' do
   let :chef_run do
     ChefSpec::Runner.new do |node|
-      node.set[:kafka] = kafka_attributes
-      node.set[:kafka][:broker] = broker_attributes
+      node.set['kafka'] = kafka_attributes
+      node.set['kafka']['broker'] = broker_attributes
     end.converge(*described_recipes)
   end
 
@@ -59,7 +59,7 @@ describe 'kafka::_configure' do
       context 'when broker id is larger than 2**31' do
         let :chef_run do
           ChefSpec::Runner.new do |node|
-            node.automatic[:ipaddress] = '255.255.255.255'
+            node.automatic['ipaddress'] = '255.255.255.255'
           end.converge(*described_recipes)
         end
 
@@ -92,13 +92,13 @@ describe 'kafka::_configure' do
     context 'configuration using underscore notation' do
       it_behaves_correctly 'when value is an Array' do
         let :broker_attributes do
-          {array_option: mappings}
+          {'array_option' => mappings}
         end
       end
 
       it_behaves_correctly 'when configuration name contains both `_` and `.`' do
         let :broker_attributes do
-          {:'possible.future_option' => mappings}
+          {'possible.future_option' => mappings}
         end
       end
     end
@@ -120,13 +120,13 @@ describe 'kafka::_configure' do
     context 'configuration using nested Hashes notation' do
       it_behaves_correctly 'when value is an Array' do
         let :broker_attributes do
-          { array: { option: mappings } }
+          { 'array' => { 'option' => mappings } }
         end
       end
 
       it_behaves_correctly 'when configuration name contains both `_` and `.`' do
         let :broker_attributes do
-          { possible: { :'future_option' => mappings } }
+          { 'possible' => { 'future_option' => mappings } }
         end
       end
     end
@@ -178,9 +178,9 @@ describe 'kafka::_configure' do
     end
 
     it 'configures sane date patterns for appenders' do
-      expect(node.kafka.log4j.appenders).to_not be_empty
-      node.kafka.log4j.appenders.each do |_, opts|
-        expect(opts.date_pattern).to eq('.yyyy-MM-dd')
+      expect(node['kafka']['log4j']['appenders']).to_not be_empty
+      node['kafka']['log4j']['appenders'].each do |_, opts|
+        expect(opts['date_pattern']).to eq('.yyyy-MM-dd')
       end
     end
   end
@@ -188,9 +188,9 @@ describe 'kafka::_configure' do
   shared_examples_for 'an init style' do
     let :chef_run do
       ChefSpec::Runner.new(platform_and_version) do |node|
-        node.set[:kafka][:scala_version] = '2.8.0'
-        node.set[:kafka][:init_style] = init_style
-        node.set[:kafka][:broker] = broker_attributes
+        node.set['kafka']['scala_version'] = '2.8.0'
+        node.set['kafka']['init_style'] = init_style
+        node.set['kafka']['broker'] = broker_attributes
       end.converge(*described_recipes)
     end
 
@@ -516,7 +516,7 @@ describe 'kafka::_configure' do
 
       context 'when set to true' do
         let :kafka_attributes do
-          {automatic_restart: true}
+          {'automatic_restart' => true}
         end
 
         it 'restarts kafka when configuration is changed' do
@@ -540,7 +540,7 @@ describe 'kafka::_configure' do
 
       context 'when set to true' do
         let :kafka_attributes do
-          {automatic_start: true}
+          {'automatic_start' => true}
         end
 
         it 'starts kafka' do

--- a/spec/recipes/defaults_spec.rb
+++ b/spec/recipes/defaults_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 describe 'kafka::_defaults' do
   let :chef_run do
     r = ChefSpec::Runner.new do |node|
-      node.set.kafka.broker = broker_attributes
+      node.set['kafka']['broker'] = broker_attributes
     end
     r.converge(described_recipe)
   end
@@ -22,52 +22,52 @@ describe 'kafka::_defaults' do
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker['broker.id']).to eq('set')
+        expect(node['kafka']['broker']['broker.id']).to eq('set')
       end
 
       it 'does not set it using other notations' do
-        expect { node.kafka.broker.broker_id }.to raise_error(NoMethodError)
-        expect { node.kafka.broker.id }.to raise_error(NoMethodError)
+        expect(node['kafka']['broker']['broker_id']).to be_nil
+        expect { node['kafka']['broker']['broker']['id'] }.to raise_error(NoMethodError)
       end
     end
 
     context 'when set using nested hash notation' do
       let :broker_attributes do
-        {broker: {id: 'set'}}
+        {'broker' => {'id' => 'set'}}
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker.broker.id).to eq('set')
+        expect(node['kafka']['broker']['broker']['id']).to eq('set')
       end
 
       it 'does not set it using other notations' do
-        expect(node.kafka.broker['broker.id']).to be_nil
-        expect { node.kafka.broker.broker_id }.to raise_error(NoMethodError)
+        expect(node['kafka']['broker']['broker.id']).to be_nil
+        expect(node['kafka']['broker']['broker_id']).to be_nil
       end
     end
 
     context 'when set using underscore notation' do
       let :broker_attributes do
-        {broker_id: 'set'}
+        {'broker_id' => 'set'}
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker.broker_id).to eq('set')
+        expect(node['kafka']['broker']['broker_id']).to eq('set')
       end
 
       it 'does not set it using other notations' do
-        expect(node.kafka.broker['broker.id']).to be_nil
-        expect { node.kafka.broker.broker.id }.to raise_error(NoMethodError)
+        expect(node['kafka']['broker']['broker.id']).to be_nil
+        expect { node['kafka']['broker']['broker']['id'] }.to raise_error(NoMethodError)
       end
     end
 
     context 'when set to `nil`' do
       let :broker_attributes do
-        {broker: {id: nil}}
+        {'broker' => {'id' => nil}}
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker['broker']['id']).to be_nil
+        expect(node['kafka']['broker']['broker']['id']).to be_nil
       end
     end
 
@@ -77,7 +77,7 @@ describe 'kafka::_defaults' do
       end
 
       it 'does override it' do
-        expect(node.kafka.broker.broker_id).to_not be_nil
+        expect(node['kafka']['broker']['broker_id']).to_not be_nil
       end
     end
   end
@@ -85,21 +85,21 @@ describe 'kafka::_defaults' do
   context 'port' do
     context 'when set' do
       let :broker_attributes do
-        {port: 9093}
+        {'port' => 9093}
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker.port).to eq(9093)
+        expect(node['kafka']['broker']['port']).to eq(9093)
       end
     end
 
     context 'when set to `nil`' do
       let :broker_attributes do
-        {port: nil}
+        {'port' => nil}
       end
 
       it 'does not override it' do
-        expect(node.kafka.broker.port).to be_nil
+        expect(node['kafka']['broker']['port']).to be_nil
       end
     end
 
@@ -109,7 +109,7 @@ describe 'kafka::_defaults' do
       end
 
       it 'does override it' do
-        expect(node.kafka.broker.port).to eq(6667)
+        expect(node['kafka']['broker']['port']).to eq(6667)
       end
     end
   end

--- a/spec/recipes/setup_spec.rb
+++ b/spec/recipes/setup_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'kafka::_setup' do
   let :chef_run do
     ChefSpec::Runner.new do |node|
-      node.set[:kafka] = kafka_attrs
+      node.set['kafka'] = kafka_attrs
     end.converge('kafka::_defaults', described_recipe)
   end
 
@@ -29,7 +29,7 @@ describe 'kafka::_setup' do
 
     context 'when disabled' do
       let :kafka_attrs do
-        {manage_user: false}
+        {'manage_user' => false}
       end
 
       it 'does not create a kafka group' do
@@ -46,7 +46,7 @@ describe 'kafka::_setup' do
 
     context 'when overridden' do
       let :kafka_attrs do
-        {user: 'spec', group: 'spec'}
+        {'user' => 'spec', 'group' => 'spec'}
       end
 
       it 'creates a group with set name' do
@@ -103,8 +103,8 @@ describe 'kafka::_setup' do
     context 'when using `underscore` notation' do
       let :kafka_attrs do
         {
-          broker: {
-            log_dirs: %w[/mnt/kafka-1 /mnt/kafka-2]
+          'broker' => {
+            'log_dirs' => %w[/mnt/kafka-1 /mnt/kafka-2]
           }
         }
       end
@@ -115,9 +115,9 @@ describe 'kafka::_setup' do
     context 'when using `nested hash` notation' do
       let :kafka_attrs do
         {
-          broker: {
-            log: {
-              dirs: %w[/mnt/kafka-1 /mnt/kafka-2]
+          'broker' => {
+            'log' => {
+              'dirs' => %w[/mnt/kafka-1 /mnt/kafka-2]
             }
           }
         }
@@ -129,7 +129,7 @@ describe 'kafka::_setup' do
     context 'when using String keys' do
       let :kafka_attrs do
         {
-          broker: {
+          'broker' => {
             'log.dirs' => %w[/mnt/kafka-1 /mnt/kafka-2]
           }
         }

--- a/templates/default/env.erb
+++ b/templates/default/env.erb
@@ -1,13 +1,13 @@
-<%= render_variable('SCALA_VERSION', node.kafka.scala_version, export?) %>
-<%= render_variable('JMX_PORT', node.kafka.jmx_port, export?) %>
+<%= render_variable('SCALA_VERSION', node['kafka']['scala_version'], export?) %>
+<%= render_variable('JMX_PORT', node['kafka']['jmx_port'], export?) %>
 
-<%= render_variable('KAFKA_LOG4J_OPTS', sprintf('-Dlog4j.configuration=file:%s', ::File.join(node.kafka.config_dir, 'log4j.properties')), export?) %>
-<%= render_variable('KAFKA_HEAP_OPTS', node.kafka.heap_opts, export?) %>
-<%= render_variable('KAFKA_GC_LOG_OPTS', node.kafka.gc_log_opts, export?) %>
-<%= render_variable('KAFKA_OPTS', node.kafka.generic_opts, export?) %>
-<%= render_variable('KAFKA_JVM_PERFORMANCE_OPTS', node.kafka.jvm_performance_opts, export?) %>
-<%= render_variable('KAFKA_JMX_OPTS', node.kafka.jmx_opts, export?) %>
+<%= render_variable('KAFKA_LOG4J_OPTS', sprintf('-Dlog4j.configuration=file:%s', ::File.join(node['kafka']['config_dir'], 'log4j.properties')), export?) %>
+<%= render_variable('KAFKA_HEAP_OPTS', node['kafka']['heap_opts'], export?) %>
+<%= render_variable('KAFKA_GC_LOG_OPTS', node['kafka']['gc_log_opts'], export?) %>
+<%= render_variable('KAFKA_OPTS', node['kafka']['generic_opts'], export?) %>
+<%= render_variable('KAFKA_JVM_PERFORMANCE_OPTS', node['kafka']['jvm_performance_opts'], export?) %>
+<%= render_variable('KAFKA_JMX_OPTS', node['kafka']['jmx_opts'], export?) %>
 
-<%= render_variable('KAFKA_RUN', ::File.join(node.kafka.install_dir, 'bin', 'kafka-run-class.sh')) %>
+<%= render_variable('KAFKA_RUN', ::File.join(node['kafka']['install_dir'], 'bin', 'kafka-run-class.sh')) %>
 <%= render_variable('KAFKA_ARGS', 'kafka.Kafka') %>
-<%= render_variable('KAFKA_CONFIG', ::File.join(node.kafka.config_dir, 'server.properties')) %>
+<%= render_variable('KAFKA_CONFIG', ::File.join(node['kafka']['config_dir'], 'server.properties')) %>


### PR DESCRIPTION
As pointed out in #104, method access (`node.foo.bar`) is deprecated and will be removed in Chef 13, and newer versions of Chef produce a large deprecation warning when anything else than bracket syntax is used.

~~I need to have a look at the tests as well (to stay consistent).~~