### PR TITLE
Allow overriding UID during user creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,3 @@ DEPENDENCIES
   rake
   stove
   test-kitchen
-
-BUNDLED WITH
-   1.10.6

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -77,6 +77,10 @@ default['kafka']['uid'] = nil
 default['kafka']['group'] = 'kafka'
 
 #
+# Override GID for Group for directories, configuration files and running Kafka.
+default['kafka']['gid'] = nil
+
+#
 # JVM heap options for Kafka.
 default['kafka']['heap_opts'] = '-Xmx1G -Xms1G'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,6 +69,10 @@ default['kafka']['user'] = 'kafka'
 default['kafka']['manage_user'] = true
 
 #
+# Override UID for User for directories, configuration files and running Kafka.
+default['kafka']['uid'] = nil
+
+#
 # Group for directories, configuration files and running Kafka.
 default['kafka']['group'] = 'kafka'
 

--- a/recipes/_setup.rb
+++ b/recipes/_setup.rb
@@ -4,11 +4,12 @@
 #
 
 group node['kafka']['group'] do
+  gid node['kafka']['gid'] if node['kafka']['gid']
   only_if { node['kafka']['manage_user'] }
 end
 
 user node['kafka']['user'] do
-  gid node['kafka']['group']
+  gid node['kafka']['gid'] if node['kafka']['gid']
   uid node['kafka']['uid'] if node['kafka']['uid']
   home '/var/empty/kafka'
   shell '/sbin/nologin'

--- a/recipes/_setup.rb
+++ b/recipes/_setup.rb
@@ -9,6 +9,7 @@ end
 
 user node['kafka']['user'] do
   gid node['kafka']['group']
+  uid node['kafka']['uid'] if node['kafka']['uid']
   home '/var/empty/kafka'
   shell '/sbin/nologin'
   only_if { node['kafka']['manage_user'] }

--- a/spec/recipes/setup_spec.rb
+++ b/spec/recipes/setup_spec.rb
@@ -27,6 +27,24 @@ describe 'kafka::_setup' do
       end
     end
 
+    context 'when uid' do
+      let :kafka_attrs do
+        {uid: 1234}
+      end
+
+      it 'creates a kafka group' do
+        expect(chef_run).to create_group('kafka')
+      end
+
+      it 'creates a kafka user' do
+        expect(chef_run).to create_user('kafka').with({
+          shell: '/sbin/nologin',
+          gid: 'kafka',
+          uid: 1234
+        })
+      end
+    end
+
     context 'when disabled' do
       let :kafka_attrs do
         {'manage_user' => false}

--- a/spec/recipes/setup_spec.rb
+++ b/spec/recipes/setup_spec.rb
@@ -21,15 +21,14 @@ describe 'kafka::_setup' do
 
       it 'creates a kafka user' do
         expect(chef_run).to create_user('kafka').with({
-          shell: '/sbin/nologin',
-          gid: 'kafka'
+          shell: '/sbin/nologin'
         })
       end
     end
 
-    context 'when uid' do
+    context 'when uid and gid' do
       let :kafka_attrs do
-        {uid: 1234}
+        {uid: 1234, gid: 5678}
       end
 
       it 'creates a kafka group' do
@@ -39,7 +38,7 @@ describe 'kafka::_setup' do
       it 'creates a kafka user' do
         expect(chef_run).to create_user('kafka').with({
           shell: '/sbin/nologin',
-          gid: 'kafka',
+          gid: 5678,
           uid: 1234
         })
       end
@@ -73,8 +72,7 @@ describe 'kafka::_setup' do
 
       it 'creates a user with set name' do
         expect(chef_run).to create_user('spec').with({
-          shell: '/sbin/nologin',
-          gid: 'spec'
+          shell: '/sbin/nologin'
         })
       end
     end


### PR DESCRIPTION
This is useful when you want to make sure the user has the same UID across all hosts.


Side note: will rebase once https://github.com/mthssdrbrg/kafka-cookbook/pull/106 is merged since i assumed that syntax would be used