### PR TITLE
Reload systemd unit file on changes

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -30,9 +30,17 @@ template kafka_init_opts[:script_path] do
   helper :controlled_shutdown_enabled? do
     !!fetch_broker_attribute(:controlled, :shutdown, :enable)
   end
+  if kafka_init_style == :systemd
+    notifies :run, 'execute[kafka systemctl daemon-reload]', :immediately
+  end
   if restart_on_configuration_change?
     notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
   end
 end
+
+execute 'kafka systemctl daemon-reload' do
+  command 'systemctl daemon-reload'
+  action :nothing
+end if kafka_init_style == :systemd
 
 include_recipe node['kafka']['start_coordination']['recipe']

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -459,6 +459,11 @@ describe 'kafka::_configure' do
           'systemd/default.erb'
         end
 
+        it 'reloads unit files' do
+          expect(chef_run.execute('kafka systemctl daemon-reload')).to do_nothing
+          expect(chef_run.template(init_path)).to notify('execute[kafka systemctl daemon-reload]').to(:run).immediately
+        end
+
         context 'and platform is \'debian\'' do
           it_behaves_like 'an init style' do
             let :platform_and_version do

--- a/test/integration/systemd/serverspec/service_spec.rb
+++ b/test/integration/systemd/serverspec/service_spec.rb
@@ -18,10 +18,6 @@ describe 'service for systemd init style' do
     'systemctl status kafka.service'
   end
 
-  before :all do
-    run_command 'systemctl daemon-reload'
-  end
-
   before do
     run_command 'systemctl reset-failed kafka.service'
   end

--- a/vagrantfiles/cachier.rb
+++ b/vagrantfiles/cachier.rb
@@ -1,4 +1,5 @@
 Vagrant.configure('2') do |c|
+  c.ssh.insert_key = false
   if Vagrant.has_plugin?('vagrant-cachier')
     c.cache.auto_detect = true
     c.cache.scope = :box


### PR DESCRIPTION
If one changes for example the `ulimit` value it won't be picked up on the next restart of Kafka as `systemd` won't know about it. See #110.

Would be nice if `systemd` could reload just a single unit file, but I don't think that's possible. 