### PR TITLE
systemd: wait for network before starting Kafka

### DIFF
--- a/templates/default/systemd/default.erb
+++ b/templates/default/systemd/default.erb
@@ -1,5 +1,7 @@
 [Unit]
 Description=<%= @daemon_name %> daemon
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 User=<%= @user %>


### PR DESCRIPTION
The background for this is #114 and really should've been there from the start. Without this change Kafka will be started parallel to a lot of things, one of them being the network (most likely at least).