### PR TITLE
Deal with potentially sensitive configuration values

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -27,6 +27,7 @@ template ::File.join(node['kafka']['config_dir'], 'server.properties') do
   owner node['kafka']['user']
   group node['kafka']['group']
   mode '644'
+  sensitive true
   helpers(Kafka::Configuration)
   variables(config: node['kafka']['broker'].sort_by(&:first))
   if restart_on_configuration_change?

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -26,7 +26,7 @@ template ::File.join(node['kafka']['config_dir'], 'server.properties') do
   source 'server.properties.erb'
   owner node['kafka']['user']
   group node['kafka']['group']
-  mode '644'
+  mode '600'
   sensitive true
   helpers(Kafka::Configuration)
   variables(config: node['kafka']['broker'].sort_by(&:first))

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -43,7 +43,7 @@ describe 'kafka::_configure' do
       expect(chef_run).to create_template(path).with(
         owner: 'kafka',
         group: 'kafka',
-        mode: '644',
+        mode: '600',
       )
     end
 

--- a/test/integration/helpers/serverspec/support/files_common.rb
+++ b/test/integration/helpers/serverspec/support/files_common.rb
@@ -41,8 +41,8 @@ shared_examples_for 'a non-executable kafka file' do
 
   it_behaves_like 'a kafka file'
 
-  it 'has 644 permissions' do
-    expect(kafka_file).to be_mode 644
+  it 'has expected permissions' do
+    expect(kafka_file).to be_mode(644).or be_mode(600)
   end
 end
 


### PR DESCRIPTION
As mentioned in #118, Kafka v0.9+ supports SSL and hence the broker configuration file can contain passphrase for keystore and truststore. This PR implements the suggestions outlined in the issue.