### PR TITLE
Update Debian SysV init script for LSB pidofproc behavior

### DIFF
--- a/templates/default/sysv/debian.erb
+++ b/templates/default/sysv/debian.erb
@@ -45,7 +45,7 @@ do_stop()
   <% if controlled_shutdown_enabled? %>
   start-stop-daemon --stop --quiet --oknodo --signal=TERM --pidfile "$PIDFILE"
   RETVAL=$?
-  while pidofproc "$PIDFILE" "$KAFKA"; do sleep 1; done
+  while pidofproc "$NAME"; do sleep 1; done
   <% else %>
   start-stop-daemon --stop --quiet --oknodo --retry=TERM/<%= @kill_timeout %>/KILL/5 --pidfile "$PIDFILE"
   RETVAL=$?


### PR DESCRIPTION
The current version of the `sysv/debian` template is breaking on Ubuntu 14.04.   The `pidofproc` function defined in `/lib/lsb/init-functions` appears to only work when taking a _pathname_ argument (described in LSB 3.0.0)

How to re-create: Attempt `bash -x /etc/init.d/kafka stop` or `bash -x /etc/init.d/kafka restart` on Ubuntu 14.04, and you will receive an error on STDERR:

```
+ pidofproc /var/run/kafka.pid ''
+ local pidfile base status specified pid OPTIND
+ pidfile=
+ specified=
+ OPTIND=1
+ getopts p: opt
+ shift 0
+ '[' 2 -ne 1 ']'
+ echo '/etc/init.d/kafka: invalid arguments'
/etc/init.d/kafka: invalid arguments
```

This patch fixes this issue.