### PR TITLE
Move Kafka service to `_service` recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,6 @@ ruby_block 'restart-coordination' do
   notifies :create, 'ruby_block[restart-coordination-cleanup]', :delayed
 end
 
-service 'kafka' do
-  provider kafka_init_opts[:provider]
-  supports start: true, stop: true, restart: true, status: true
-  action kafka_service_actions
-end
-
 ruby_block 'restart-coordination-cleanup' do
   block do
     Chef::Log.info 'Implement any cleanup logic required after restart like releasing locks'

--- a/recipes/_coordinate.rb
+++ b/recipes/_coordinate.rb
@@ -10,9 +10,3 @@ ruby_block 'coordinate-kafka-start' do
   action :nothing
   notifies :restart, 'service[kafka]', :delayed
 end
-
-service 'kafka' do
-  provider kafka_init_opts[:provider]
-  supports start: true, stop: true, restart: true, status: true
-  action kafka_service_actions
-end

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -43,4 +43,10 @@ execute 'kafka systemctl daemon-reload' do
   action :nothing
 end if kafka_init_style == :systemd
 
+service 'kafka' do
+  provider kafka_init_opts[:provider]
+  supports start: true, stop: true, restart: true, status: true
+  action kafka_service_actions
+end
+
 include_recipe node['kafka']['start_coordination']['recipe']


### PR DESCRIPTION
Don't recall why this wasn't done from the beginning, but it does seem like a way better fit (can't think of any downsides off the top of my head, but there may be some), and it'll make it way easier/nicer to integrate with `runit`.

Note that this is a work in progress and currently contains some other changes that are being added in a separate branch/PR.