### PR TITLE
Fixed local download path to verify with MD5. 

### DIFF
--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -10,21 +10,19 @@ remote_file kafka_local_download_path do
   source kafka_download_uri(kafka_tar_gz)
   mode '644'
   checksum sha256 if sha256 && !sha256.empty?
-  notifies :create, 'ruby_block[kafka-validate-download]', :immediately
   not_if { kafka_installed? }
 end
 
 ruby_block 'kafka-validate-download' do
   block do
     if md5 && !md5.empty?
-      unless (checksum = Digest::MD5.file(local_file_path).hexdigest) == md5.downcase
+      unless (checksum = Digest::MD5.file(kafka_local_download_path).hexdigest) == md5.downcase
         Chef::Application.fatal! %(Downloaded tarball checksum (#{checksum}) does not match provided checksum (#{md5}))
       end
     else
       Chef::Log.debug 'No MD5 checksum set, not validating downloaded archive'
     end
   end
-  action :nothing
   not_if { kafka_installed? }
 end
 


### PR DESCRIPTION
local_file_path is not defined anywhere. Chef fails on first time run. Second run is fine because distribution archive is already there, ruby_block resource is not notified. 
Fixed security issue - the second chef run wouldn't check downloaded file vs MD5.