### PR TITLE
Delay restarts until end of Chef run

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -18,7 +18,7 @@ template ::File.join(node['kafka']['config_dir'], 'log4j.properties') do
   helpers(Kafka::Log4J)
   variables(config: node['kafka']['log4j'])
   if restart_on_configuration_change?
-    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :delayed
   end
 end
 
@@ -31,6 +31,6 @@ template ::File.join(node['kafka']['config_dir'], 'server.properties') do
   helpers(Kafka::Configuration)
   variables(config: node['kafka']['broker'].sort_by(&:first))
   if restart_on_configuration_change?
-    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :delayed
   end
 end

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -50,7 +50,7 @@ runit_service 'kafka' do
   )
   sv_bin format('sleep 5 && %s', node['runit']['sv_bin'])
   restart_on_update false
-  start_down true
+  start_down true unless start_automatically?
   sv_timeout node['kafka']['kill_timeout'] if node['kafka']['kill_timeout']
   control %w[t] if fetch_broker_attribute(:controlled, :shutdown, :enable)
   if restart_on_configuration_change?

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -9,7 +9,7 @@ file kafka_init_opts[:env_path] do
   mode '644'
   content kafka_env.to_file_content(!kafka_systemd?)
   if restart_on_configuration_change?
-    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :delayed
   end
 end unless kafka_runit?
 
@@ -33,7 +33,7 @@ template kafka_init_opts[:script_path] do
     notifies :run, 'execute[kafka systemctl daemon-reload]', :immediately
   end
   if restart_on_configuration_change?
-    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
+    notifies :create, 'ruby_block[coordinate-kafka-start]', :delayed
   end
 end unless kafka_runit?
 

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -53,9 +53,6 @@ runit_service 'kafka' do
   start_down true unless start_automatically?
   sv_timeout node['kafka']['kill_timeout'] if node['kafka']['kill_timeout']
   control %w[t] if fetch_broker_attribute(:controlled, :shutdown, :enable)
-  if restart_on_configuration_change?
-    notifies :create, 'ruby_block[coordinate-kafka-start]', :immediately
-  end
   action kafka_service_actions
 end if kafka_runit?
 


### PR DESCRIPTION
The previous behaviour could result in multiple restarts in one Chef run, if for example environment variables used by the init scripts and the broker configuration was updated. By using `:delayed` this should no longer be the case, and Chef will deduplicate notifications.

This also removes the notification from the `runit_service` as it for some reason always seem to trigger notifs even if nothing has changed (tested by running multiple converges without changing anything).