### PR TITLE
Add syslog identifier to systemd unit

### DIFF
--- a/templates/default/systemd/default.erb
+++ b/templates/default/systemd/default.erb
@@ -6,6 +6,7 @@ After=network-online.target
 [Service]
 User=<%= @user %>
 EnvironmentFile=<%= @env_path %>
+SyslogIdentifier=kafka
 ExecStart=/bin/bash $KAFKA_RUN $KAFKA_ARGS $KAFKA_CONFIG
 TimeoutSec=10
 TimeoutStopSec=<%= @kill_timeout %>


### PR DESCRIPTION
This adds a "kafka" syslog identifier so this stops showing up as "bash" in the systemd journal.